### PR TITLE
docs: rename coordinate transforms to coordinate transformations

### DIFF
--- a/docs/source/annotation_set.rst
+++ b/docs/source/annotation_set.rst
@@ -30,14 +30,14 @@ Files
 -----
 ``annotations.ome.zarr``
   * OME-Zarr 0.5 multiscale
-  * Correct coordinate transforms
+  * Correct coordinate transformations
   * Units in millimeters
   * Dimensions: ``AZYX`` (A = annotation label dimension)    
 
 ``annotations_compressed.ome.zarr``
   * Single integer label per voxel variant of ``annotations`` array.
   * OME-Zarr 0.5 multiscale
-  * Correct coordinate transforms
+  * Correct coordinate transformations
   * Dimensions: ``ZYX``
   s (millimeters)
 

--- a/docs/source/coordinate_transformation.rst
+++ b/docs/source/coordinate_transformation.rst
@@ -1,9 +1,9 @@
-Coordinate Transform
-====================
+Coordinate Transformation
+=========================
 
-.. _coordinate-transform:
+.. _coordinate-transformation:
 
-A Coordinate Transform asset defines one or more mathematical operations that map physical coordinates from a source Template to a target Template. Transforms can be directional (source → target) or bidirectional (both directions with validated inverses).
+A Coordinate Transformation asset defines one or more mathematical operations that map physical coordinates from a source Template to a target Template. Transformations can be directional (source → target) or bidirectional (both directions with validated inverses).
 
 Typical use cases:
 
@@ -17,18 +17,18 @@ Follows the pattern shown in the global layout (subset repeated here):
 
 .. code-block:: text
 
-   coordinate-transforms/
+   coordinate-transformations/
      └── <source_template>-<source_version>_to_<target_template>-<target_version>/
          └── <version>/
-             ├── data_description.json          (REQUIRED)
-             ├── processing.json                (REQUIRED if computed)
-             ├── manifest.json                  (REQUIRED)
-             ├── coordinate_transforms.ome.zarr (OPTIONAL)
-             └── <ANTs files>                   (OPTIONAL)
+             ├── data_description.json               (REQUIRED)
+             ├── processing.json                     (REQUIRED if computed)
+             ├── manifest.json                       (REQUIRED)
+             ├── coordinate_transformations.ome.zarr (OPTIONAL)
+             └── <ANTs files>                        (OPTIONAL)
 
 Naming Conventions
 ------------------
-Top-level transform folder name:
+Top-level transformation folder name:
 
 ``<source_template>-<source_version>_to_<target_template>-<target_version>``
 
@@ -43,7 +43,7 @@ Version Subdirectory:
 Files
 -----
 ``data_description.json``
-  * Conforms to ``aind_data_schema >= 2.0``. 
+  * Conforms to ``aind_data_schema >= 2.0``.
   * Describes purpose, provenance, authorship, licensing, source & target references.
 
 ``processing.json``
@@ -53,9 +53,9 @@ Files
   * ``source`` – object with template name/version & coordinate space name/version
   * ``target`` – object with template name/version & coordinate space name/version
   * ``directionality`` – ``one-way`` | ``bidirectional``
-  
-``coordinate_transforms.ome.zarr``
-  * OME-Zarr 0.5 container encoding transform chain using multiscale / coordinateTransform metadata. Can contain:
+
+``coordinate_transformations.ome.zarr``
+  * OME-Zarr 0.5 container encoding transformation chain using multiscale / coordinateTransformations metadata. Can contain:
   * Displacement field(s)
   * Affine matrices
 
@@ -68,7 +68,6 @@ Files
 Versioning
 ----------
 Increment version when:
-* Any component transform changes (affine parameters, warp field recalculation)
+* Any component transformation changes (affine parameters, warp field recalculation)
 * Underlying source or target template version changes
 * Directionality changes (e.g., adding validated inverse)
-

--- a/docs/source/example_atlas_assets.rst
+++ b/docs/source/example_atlas_assets.rst
@@ -31,9 +31,9 @@ This page provides examples of actual atlas assets currently available in the Al
    │   └── allen-adult-mouse-spim-lca-template/
    │       └── 2024-05/  # the SmartSPIM template in production now
    │
-   ├── coordinate-transforms/
+   ├── coordinate-transformations/
    │   └── allen-adult-mouse-spim-lca-2024-05_to_allen-adult-mouse-stpt-2015/
-   │       └── 2024-05/  # transform between SmartSPIM template and 2p template
+   │       └── 2024-05/  # transformation between SmartSPIM template and 2p template
    │
    ├── coordinate-spaces/
    │   ├── allen-adult-mouse-ccf-space/

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -84,17 +84,17 @@ A parcellation terminology is a versioned release of a set of terms that can be 
 
 For implementation details (directory layout, file schema, validation rules) see :doc:`terminology`.
 
-Coordinate Transform
---------------------
+Coordinate Transformation
+-------------------------
 
 One or more concatenated mathematical operations that convert the physical coordinates of one template to another.
 
 .. note::
    This is not part of the existing BICAN data model.
 
-**Practically:** transforms, including nonlinear warps, defined specifically enough that we can map coordinates between anatomical spaces without secret code.
+**Practically:** transformations, including nonlinear warps, defined specifically enough that we can map coordinates between anatomical spaces without secret code.
 
-For implementation details (naming, files, validation rules) see :doc:`coordinate_transform`.
+For implementation details (naming, files, validation rules) see :doc:`coordinate_transformation`.
 
 =================
 File Organization
@@ -137,13 +137,13 @@ The S3 bucket structure is organized as follows:
    │           ├── terminology.parquet (OPTIONAL)
    │           └── terminology.csv (REQUIRED)
    │
-   └── coordinate-transforms/
+   └── coordinate-transformations/
        └── <template>-<version>_to_<template>-<version>/
            └── <version>/
                ├── data_description.json (REQUIRED)
                ├── processing.json (REQUIRED if computed)
                ├── manifest.json (REQUIRED)
-               ├── coordinate_transforms.ome.zarr (OPTIONAL)
+               ├── coordinate_transformations.ome.zarr (OPTIONAL)
                └── <ANTs files> (OPTIONAL)
 
 Metadata
@@ -166,7 +166,7 @@ All computed assets (e.g. some templates) must have a processing.json in the top
    template
    annotation_set
    terminology
-   coordinate_transform
+   coordinate_transformation
 
 .. toctree::
    :maxdepth: 1

--- a/docs/source/template.rst
+++ b/docs/source/template.rst
@@ -30,7 +30,7 @@ Files
 -----
 ``template.ome.zarr``
   * OME-Zarr 0.5
-  * Coordinate transforms + orientation present
+  * Coordinate transformations + orientation present
   * Millimeter units
 
 ``template.nii.gz``
@@ -47,8 +47,8 @@ Files
 Validation Rules
 ----------------
 * OME-Zarr multiscales metadata valid and consistent (scale factors monotonic).
-* Anatomical orientation and coordinate transforms are defined and consistent across provided formats.
-* No missing scale levels referenced by transforms.
+* Anatomical orientation and coordinate transformations are defined and consistent across provided formats.
+* No missing scale levels referenced by transformations.
 
 Versioning
 ----------


### PR DESCRIPTION
Renames the coordinate-transforms storage location to coordinate-transformations and updates all text references throughout the docs to use "transformation(s)" instead of "transform(s)". Also renames coordinate_transform.rst to coordinate_transformation.rst and updates the OME-Zarr container filename to coordinate_transformations.ome.zarr.

Fixes #14