### PR TITLE
docs: clarify atlas as grouping multiple annotation sets and templates

### DIFF
--- a/docs/source/atlas.rst
+++ b/docs/source/atlas.rst
@@ -3,7 +3,7 @@ Atlas
 
 .. _atlas:
 
-An Atlas release bundles specific versions of the component assets required to interpret anatomical annotations in a defined coordinate space. It references (does not duplicate) one Coordinate Space, one or more Templates, and one or more Annotation Sets — all anchored to that single Coordinate Space. Each referenced Annotation Set brings its own Terminology, so a single atlas can group annotations that use different terminologies as long as they share the coordinate space. The atlas itself is mostly metadata + a manifest tying these components together.
+An Atlas release bundles specific versions of the component assets required to interpret anatomical annotations in a defined coordinate space. It references (does not duplicate) one Coordinate Space, one or more Templates, and one or more Annotation Sets — all anchored to that single Coordinate Space. Each referenced Annotation Set brings its own unique Terminology, so a single atlas can group annotations that use different terminologies as long as they share the coordinate space. The atlas itself is mostly metadata + a manifest tying these components together.
 
 Directory Structure
 -------------------

--- a/docs/source/atlas.rst
+++ b/docs/source/atlas.rst
@@ -3,7 +3,7 @@ Atlas
 
 .. _atlas:
 
-An Atlas release bundles specific versions of the component assets required to interpret anatomical annotations in a defined coordinate space. It references (does not duplicate) one Coordinate Space, one Terminology, and one Annotation Set. The atlas itself is mostly metadata + a manifest tying these together.
+An Atlas release bundles specific versions of the component assets required to interpret anatomical annotations in a defined coordinate space. It references (does not duplicate) one Coordinate Space, one or more Templates, and one or more Annotation Sets — all anchored to that single Coordinate Space. Each referenced Annotation Set brings its own Terminology, so a single atlas can group annotations that use different terminologies as long as they share the coordinate space. The atlas itself is mostly metadata + a manifest tying these components together.
 
 Directory Structure
 -------------------
@@ -39,16 +39,17 @@ Files
   Canonical reference list to component assets. Minimal required keys (draft):
 
   * ``coordinate_space`` – object with ``name`` and ``version``
-  * ``terminology`` – object with ``name`` and ``version``
-  * ``annotation_set`` – object with ``name`` and ``version``
+  * ``templates`` – list of objects, each with ``name`` and ``version``
+  * ``annotation_sets`` – list of objects, each with ``name`` and ``version`` (terminology is referenced by the annotation set itself)
   * ``created`` – ISO 8601 date/time of atlas release
   * ``schema_version`` – version of future ``atlas-schema`` manifest contract
 
 Validation Rules
 ----------------
 * Each referenced component and version must exist.
-* Referenced Coordinate Space and Annotation Set must be compatible (annotation set aligned to that space version).
-* Terminology version referenced by Annotation Set should match manifest's Terminology.
+* Every referenced Template must be aligned to the manifest's Coordinate Space (matching name and version).
+* Every referenced Annotation Set must be anchored in the manifest's Coordinate Space (matching name and version).
+* Each Annotation Set's own manifest declares its Terminology; different Annotation Sets in the same atlas may use different terminologies.
 
 Versioning
 ----------

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -27,7 +27,7 @@ A parcellation atlas is a versioned release reference used to guide experiments 
 
 * One coordinate space
 * One or more templates (all in the atlas's coordinate space)
-* One or more annotation sets (all in the atlas's coordinate space; each brings its own terminology)
+* One or more annotation sets (all in the atlas's coordinate space; each brings its own unique terminology)
 
 For implementation details (structure, naming, manifest schema) see :doc:`atlas`.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -26,8 +26,8 @@ A parcellation atlas is a versioned release reference used to guide experiments 
 **Practically:** a versioned list of references (manifest) to:
 
 * One coordinate space
-* One terminology  
-* One annotation set
+* One or more templates (all in the atlas's coordinate space)
+* One or more annotation sets (all in the atlas's coordinate space; each brings its own terminology)
 
 For implementation details (structure, naming, manifest schema) see :doc:`atlas`.
 


### PR DESCRIPTION
Updates the Atlas spec to allow an atlas to reference one or more templates and one or more annotation sets, all anchored to a single coordinate space. Each annotation set carries its own terminology, so a single atlas can group annotations from different terminologies as long as the coordinate space is shared. Updates the manifest schema (templates and annotation_sets as lists) and the validation rules accordingly.

Fixes #12