### PR TITLE
docs: amplify AtOM model framing with explicit citations

### DIFF
--- a/docs/source/annotation_set.rst
+++ b/docs/source/annotation_set.rst
@@ -5,6 +5,9 @@ Annotation Set
 
 An Annotation Set partitions a Coordinate Space into labeled regions (masks, meshes) using a specific Terminology. It is versioned; new versions capture refinements, added regions, or structural corrections.
 
+.. seealso::
+   https://brain-bican.github.io/models/AnatomicalAnnotationSet/
+
 Directory Structure
 -------------------
 .. code-block:: text

--- a/docs/source/atlas.rst
+++ b/docs/source/atlas.rst
@@ -5,6 +5,9 @@ Atlas
 
 An Atlas release bundles specific versions of the component assets required to interpret anatomical annotations in a defined coordinate space. It references (does not duplicate) one Coordinate Space, one Terminology, and one Annotation Set. The atlas itself is mostly metadata + a manifest tying these together.
 
+.. seealso::
+   https://brain-bican.github.io/models/ParcellationAtlas/
+
 Directory Structure
 -------------------
 Subset of the global layout:

--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -5,7 +5,7 @@ Changelog
 This page tracks the evolution and changes made to the Atlas Asset Organization specification.
 
 **August 29, 2025**
-   Adopted AToM model with simplified terms
+   Adopted AtOM model with simplified terms
 
 **August 12, 2025**
    Renamed "2p" -> "stpt" to be consistent with historical documents

--- a/docs/source/coordinate_space.rst
+++ b/docs/source/coordinate_space.rst
@@ -5,6 +5,9 @@ Coordinate Space
 
 A Coordinate Space (anatomical space) defines the mathematical frame in which anatomical data are expressed: origin, axis directions/orientation, physical voxel spacing/units, and (optionally) an associated reference template image. Images are considered to reside in the same Coordinate Space when they are at least affine-aligned (same orientation, origin, and scaling) to the defining template/reference.
 
+.. seealso::
+   https://brain-bican.github.io/models/AnatomicalSpace/
+
 Directory Structure
 -------------------
 Subset of the global layout showing only coordinate space content (using the ``templates`` directory because the defining template typically lives there) and implicit reference from other assets:

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -13,9 +13,9 @@ This document provides a detailed overview of how brain atlas data assets are or
 Foundation
 ==========
 
-This specification operationalizes the **Atlas Ontology Model (AtOM)** [Kleven2023]_, a community ontology developed under the BICAN initiative that standardizes how brain atlases are described and used across tools, workflows, and data infrastructures. AtOM defines the core entities (parcellation atlas, anatomical space, anatomical dataset, anatomical annotation set, parcellation terminology, transformation) and the relationships between them. Each Core Concept below corresponds directly to an AtOM class; the **AtOM class** callout on each section names the linked class in the BICAN model.
+This specification operationalizes the **Atlas Ontology Model (AtOM)** [Kleven2023]_ and the **BICAN Anatomical Structure schema** (https://brain-bican.github.io/models/index_anatomical_structure/). AtOM is a community ontology, developed under the BICAN initiative, that standardizes how brain atlases are described and used across tools, workflows, and data infrastructures; it defines the core entities (parcellation atlas, anatomical space, anatomical dataset, anatomical annotation set, parcellation terminology, transformation) and the relationships between them. The BICAN Anatomical Structure schema provides the corresponding LinkML class definitions (``ParcellationAtlas``, ``AnatomicalSpace``, ``ImageDataset``, ``AnatomicalAnnotationSet``, ``ParcellationTerminology``, and the supporting ``ParcellationAnnotation`` / ``ParcellationAnnotationTermMap`` / ``ParcellationColorAssignment`` classes used inside terminology and annotation set assets).
 
-The LinkML schemas for these classes are published at https://brain-bican.github.io/models/.
+Each Core Concept below corresponds directly to a class from these models; the **AtOM class** callout on each section names the linked class, and the *seealso* block links to its published LinkML definition.
 
 .. [Kleven2023] Kleven, H., Gillespie, T.H., Zehl, L., Dickscheid, T., Bjaalie, J.G., Martone, M.E., Leergaard, T.B. (2023). *AtOM, an ontology model to standardize use of brain atlases in tools, workflows, and data infrastructures.* Scientific Data 10, 486. https://doi.org/10.1038/s41597-023-02389-4
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -66,7 +66,10 @@ Template
 
 A reference image that defines or is aligned to a Coordinate Space.
 
-**Also Known As:** average template, anatomical template, anatomical dataset
+.. seealso::
+   https://brain-bican.github.io/models/ImageDataset/
+
+**Also Known As:** average template, anatomical template, anatomical dataset, image dataset
 
 **Practically:** A reference image. Whether a template is a new revision of an existing template or a new template entirely is primarily about lineage and ease of co-registration. If the measurable differences are local/nonlinear, likely it should be a new revision. If you have to apply a nonlinear transformation, it's a new template.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -9,6 +9,16 @@ This document provides a detailed overview of how brain atlas data assets are or
 .. seealso::
    For a history of changes to this specification, see the :doc:`changelog`.
 
+==========
+Foundation
+==========
+
+This specification operationalizes the **Atlas Ontology Model (AtOM)** [Kleven2023]_, a community ontology developed under the BICAN initiative that standardizes how brain atlases are described and used across tools, workflows, and data infrastructures. AtOM defines the core entities (parcellation atlas, anatomical space, anatomical dataset, anatomical annotation set, parcellation terminology, transformation) and the relationships between them. Each Core Concept below corresponds directly to an AtOM class; the **AtOM class** callout on each section names the linked class in the BICAN model.
+
+The LinkML schemas for these classes are published at https://brain-bican.github.io/models/.
+
+.. [Kleven2023] Kleven, H., Gillespie, T.H., Zehl, L., Dickscheid, T., Bjaalie, J.G., Martone, M.E., Leergaard, T.B. (2023). *AtOM, an ontology model to standardize use of brain atlases in tools, workflows, and data infrastructures.* Scientific Data 10, 486. https://doi.org/10.1038/s41597-023-02389-4
+
 =============
 Core Concepts
 =============
@@ -16,10 +26,12 @@ Core Concepts
 Atlas
 -----
 
+**AtOM class:** ``ParcellationAtlas``
+
 A parcellation atlas is a versioned release reference used to guide experiments or deal with the spatial relationship between objects or the location of objects within the context of some anatomical structure. An atlas is minimally defined by a notion of space (either implicit or explicit) and an annotation set. Reference atlases usually have additional parts that make them more useful in certain situations, such as a well-defined coordinate system, delineations indicating the boundaries of various regions or cell populations, landmarks, and labels and names to make it easier to communicate about well-known and useful locations.
 
 .. seealso::
-   https://brain-bican.github.io/models/ParcellationAtlas/
+   AtOM ``ParcellationAtlas`` schema: https://brain-bican.github.io/models/ParcellationAtlas/
 
 **Also Known As:** parcellation atlas, reference atlas
 
@@ -34,10 +46,12 @@ For implementation details (structure, naming, manifest schema) see :doc:`atlas`
 Coordinate Space
 ----------------
 
+**AtOM class:** ``AnatomicalSpace``
+
 An anatomical space is versioned release of a mathematical space with a defined mapping between the anatomical axes and the mathematical axes. An anatomical space may be defined by a reference image chosen as the biological reference for an anatomical structure of interest derived from a single or multiple specimens.
 
 .. seealso::
-   https://brain-bican.github.io/models/AnatomicalSpace/
+   AtOM ``AnatomicalSpace`` schema: https://brain-bican.github.io/models/AnatomicalSpace/
 
 **Also Known As:** anatomical space
 
@@ -48,9 +62,11 @@ For implementation details (definition, naming, validation) see :doc:`coordinate
 Template
 --------
 
+**AtOM class:** ``AnatomicalDataset``
+
 A reference image that defines or is aligned to a Coordinate Space.
 
-**Also Known As:** average template, anatomical template
+**Also Known As:** average template, anatomical template, anatomical dataset
 
 **Practically:** A reference image. Whether a template is a new revision of an existing template or a new template entirely is primarily about lineage and ease of co-registration. If the measurable differences are local/nonlinear, likely it should be a new revision. If you have to apply a nonlinear transformation, it's a new template.
 
@@ -59,10 +75,12 @@ For implementation details (files, validation, versioning) see :doc:`template`.
 Annotation Set
 --------------
 
+**AtOM class:** ``AnatomicalAnnotationSet``
+
 An anatomical annotation set is a versioned release of a set of anatomical annotations anchored in the same anatomical space that divides the space into distinct segments following some annotation criteria or parcellation scheme. For example, the anatomical annotation set of 3D image based reference atlases (e.g. Allen Mouse CCF) can be expressed as a set of label indices of single multi-valued image annotations or as a set of segmentation masks.
 
 .. seealso::
-   https://brain-bican.github.io/models/AnatomicalAnnotationSet/
+   AtOM ``AnatomicalAnnotationSet`` schema: https://brain-bican.github.io/models/AnatomicalAnnotationSet/
 
 **Also Known As:** anatomical annotation set, structure masks, structure meshes
 
@@ -73,10 +91,12 @@ For implementation details (files, naming, versioning) see :doc:`annotation_set`
 Terminology
 -----------
 
+**AtOM class:** ``ParcellationTerminology``
+
 A parcellation terminology is a versioned release of a set of terms that can be used to label annotations in an atlas, providing human readability and context and enabling communication about brain locations and structural properties. Typically, a terminology is a set of descriptive anatomical terms following a specific naming convention and/or organizational approach. The terminology may be a flat list (controlled vocabulary), a taxonomy and partonomy, or an ontology (ref: ILX:0777107, RRID:SCR_023499).
 
 .. seealso::
-   https://brain-bican.github.io/models/ParcellationTerminology/
+   AtOM ``ParcellationTerminology`` schema: https://brain-bican.github.io/models/ParcellationTerminology/
 
 **Also Known As:** parcellation terminology, ontology, structures.csv
 
@@ -87,10 +107,9 @@ For implementation details (directory layout, file schema, validation rules) see
 Coordinate Transform
 --------------------
 
-One or more concatenated mathematical operations that convert the physical coordinates of one template to another.
+**AtOM class:** ``Transformation`` (base class)
 
-.. note::
-   This is not part of the existing BICAN data model.
+One or more concatenated mathematical operations that convert the physical coordinates of one template to another.
 
 **Practically:** transforms, including nonlinear warps, defined specifically enough that we can map coordinates between anatomical spaces without secret code.
 

--- a/docs/source/template.rst
+++ b/docs/source/template.rst
@@ -5,6 +5,9 @@ Template
 
 A Template is the reference image that defines (or is rigidly/affinely aligned to) a Coordinate Space. It serves as the anatomical backdrop for annotation, registration, and visualization.
 
+.. seealso::
+   https://brain-bican.github.io/models/ImageDataset/
+
 Directory Structure
 -------------------
 .. code-block:: text

--- a/docs/source/terminology.rst
+++ b/docs/source/terminology.rst
@@ -5,6 +5,9 @@ Terminology
 
 Terminology assets define the controlled vocabulary (taxonomy or ontology) used to label anatomical annotations in an atlas. A terminology release is versioned and immutable once published.
 
+.. seealso::
+   https://brain-bican.github.io/models/ParcellationTerminology/
+
 See core concept description under the Terminology section on the main index page for high-level background.
 
 Directory Structure


### PR DESCRIPTION
Adds a Foundation section to index.rst explaining that this specification operationalizes the Atlas Ontology Model (AtOM) from Kleven et al. 2023, with a full bibliographic reference. Each Core Concept now carries an explicit "AtOM class" callout naming the corresponding AtOM class (ParcellationAtlas, AnatomicalSpace, AnatomicalDataset, AnatomicalAnnotationSet, ParcellationTerminology, Transformation) so the mapping between this spec and AtOM is immediately visible. Also fixes the changelog spelling AToM -> AtOM and removes the stale note claiming Coordinate Transform is outside the BICAN data model.

Fixes #17