### PR TITLE
Fixes small formatting error in coordinate_transformations.rst

### DIFF
--- a/docs/source/coordinate_transformation.rst
+++ b/docs/source/coordinate_transformation.rst
@@ -68,6 +68,7 @@ Files
 Versioning
 ----------
 Increment version when:
+
 * Any component transformation changes (affine parameters, warp field recalculation)
 * Underlying source or target template version changes
 * Directionality changes (e.g., adding validated inverse)


### PR DESCRIPTION
Adds as new line character to fix formatting.

Current:
<img width="860" height="291" alt="image" src="https://github.com/user-attachments/assets/2b844e4c-a0b7-4f72-84ad-c3e719c5e10a" />

New:
<img width="860" height="291" alt="image" src="https://github.com/user-attachments/assets/8f32772d-6861-46f9-a622-beeec724dea5" />
