### PR TITLE
docs: recommend compression for annotation OME-Zarr files (#30)

### DIFF
--- a/docs/source/annotation_set.rst
+++ b/docs/source/annotation_set.rst
@@ -35,7 +35,8 @@ Files
   * OME-Zarr 0.5 multiscale
   * Correct coordinate transformations
   * Units in millimeters
-  * Dimensions: ``AZYX`` (A = annotation label dimension)    
+  * Dimensions: ``AZYX`` (A = annotation label dimension)
+  * Chunks should be compressed (e.g. Blosc/Zstd). Most OME-Zarr writers apply a sensible default, but verify when using a custom writer — uncompressed annotation volumes are extremely large.
 
 ``annotations_compressed.ome.zarr``
   * Single integer label per voxel variant of ``annotations`` array.
@@ -43,6 +44,7 @@ Files
   * Correct coordinate transformations
   * Dimensions: ``ZYX``
   s (millimeters)
+  * Chunks should be compressed (e.g. Blosc/Zstd). Most OME-Zarr writers apply a sensible default, but verify when using a custom writer — uncompressed annotation volumes are extremely large.
 
 ``annotations.precomputed``
   * stores compressed masks in Neuroglancer precomputed format


### PR DESCRIPTION
Add a note to the annotation set OME-Zarr file specs that chunks should be compressed. OME-Zarr writers typically apply a sensible default, but users with custom writers should verify, since uncompressed annotation volumes are extremely large.

resolves #30 