### PR TITLE
docs: specify OME-Zarr 0.5 as a minimum version (#29)

### DIFF
--- a/docs/source/annotation_set.rst
+++ b/docs/source/annotation_set.rst
@@ -32,14 +32,14 @@ Example: ``allen-adult-mouse-annotation``
 Files
 -----
 ``annotations.ome.zarr``
-  * OME-Zarr 0.5 multiscale
+  * OME-Zarr >= 0.5 multiscale
   * Correct coordinate transformations
   * Units in millimeters
   * Dimensions: ``AZYX`` (A = annotation label dimension)    
 
 ``annotations_compressed.ome.zarr``
   * Single integer label per voxel variant of ``annotations`` array.
-  * OME-Zarr 0.5 multiscale
+  * OME-Zarr >= 0.5 multiscale
   * Correct coordinate transformations
   * Dimensions: ``ZYX``
   s (millimeters)

--- a/docs/source/coordinate_transformation.rst
+++ b/docs/source/coordinate_transformation.rst
@@ -55,7 +55,7 @@ Files
   * ``directionality`` – ``one-way`` | ``bidirectional``
 
 ``coordinate_transformations.ome.zarr``
-  * OME-Zarr 0.5 container encoding transformation chain using multiscale / coordinateTransformations metadata. Can contain:
+  * OME-Zarr >= 0.5 container encoding transformation chain using multiscale / coordinateTransformations metadata. Can contain:
   * Displacement field(s)
   * Affine matrices
 

--- a/docs/source/template.rst
+++ b/docs/source/template.rst
@@ -32,7 +32,7 @@ Examples:
 Files
 -----
 ``template.ome.zarr``
-  * OME-Zarr 0.5
+  * OME-Zarr >= 0.5
   * Coordinate transformations + orientation present
   * Millimeter units
 


### PR DESCRIPTION
Change exact OME-Zarr version references to a minimum (>= 0.5) across the template, annotation set, and coordinate transformation specs, so newer OME-Zarr versions are permitted.

resolves #29 