### PR TITLE
docs: add optional <label> token to atlas naming convention (#23)

### DIFF
--- a/docs/source/atlas.rst
+++ b/docs/source/atlas.rst
@@ -24,12 +24,15 @@ Naming Convention
 -----------------
 Pattern for ``<atlas_name>``::
 
-   <organization>-<age>-<species>-atlas
+   <organization>-<age>-<species>-<label>-atlas
+
+``<label>`` is optional (e.g. ``ccf``).
 
 Examples:
 
-* ``allen-adult-mouse-atlas``
-* ``allen-dev-P4-mouse-atlas``
+* ``allen-adult-mouse-ccf-atlas``
+* ``allen-adult-mouse-atlas`` (no label)
+* ``allen-dev-P4-mouse-atlas`` (no label)
 
 
 


### PR DESCRIPTION
Introduce the optional <label> token to the atlas name pattern, matching the coordinate space convention (e.g. ccf).

resolves #23 