### PR TITLE
docs: derive index status version from package version

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -25,6 +25,12 @@ version = package_version
 # the version is rendered separately by _templates/sidebar/brand.html.
 html_title = project
 
+# Make the package version available to the docs as a substitution so the
+# status banner stays in sync with the release (see index.rst).
+rst_prolog = f"""
+.. |spec_status| replace:: **Status: Released — v{package_version}**
+"""
+
 # -- General configuration ---------------------------------------------------
 # https://www.sphinx-doc.org/en/master/usage/configuration.html#general-configuration
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -2,7 +2,7 @@ Atlas Asset Organization
 =========================
 
 .. note::
-   **Status: Released — v0.1.1**
+   |spec_status|
 
 This document provides a detailed overview of how brain atlas data assets are organized within an S3 bucket (``s3://allen-atlas-assets``). It describes directory structure, naming conventions, data access patterns, and governance.
 


### PR DESCRIPTION
The status banner in index.rst hardcoded the release version, so it fell out of sync on each release. Define a |spec_status| substitution in conf.py built from the package __version__ and reference it in index.rst so the banner tracks the release automatically.