### PR TITLE
docs: align (REQUIRED)/(OPTIONAL) markers into a column

### DIFF
--- a/docs/source/annotation_set.rst
+++ b/docs/source/annotation_set.rst
@@ -21,7 +21,7 @@ Directory Structure
              ├── annotations.precomputed         (REQUIRED)
              ├── annotations_smooth.precomputed  (OPTIONAL)
              ├── parcellation_volumes.csv        (OPTIONAL)
-             └── manifest.json                  (REQUIRED)
+             └── manifest.json                   (REQUIRED)
 
 Naming Convention
 -----------------

--- a/docs/source/atlas.rst
+++ b/docs/source/atlas.rst
@@ -17,8 +17,8 @@ Subset of the global layout:
    atlases/
      └── <atlas_name>/
          └── <version>/
-             ├── data_description.json   (REQUIRED)
-             └── manifest.json           (REQUIRED)
+             ├── data_description.json (REQUIRED)
+             └── manifest.json         (REQUIRED)
 
 Naming Convention
 -----------------

--- a/docs/source/coordinate_space.rst
+++ b/docs/source/coordinate_space.rst
@@ -18,7 +18,7 @@ Subset of the global layout showing only the coordinate space content:
      └── <coordinate_space_name>/
          └── <version>/
              ├── data_description.json (REQUIRED)
-             └── manifest.json (REQUIRED)
+             └── manifest.json         (REQUIRED)
 
 
 Naming Convention

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -131,49 +131,49 @@ The S3 bucket structure is organized as follows:
    │   └── <atlas_name>/
    │       └── <version>/
    │           ├── data_description.json (REQUIRED)
-   │           └── manifest.json (REQUIRED)
+   │           └── manifest.json         (REQUIRED)
    │
    ├── templates/
    │   └── <template_name>/
    │       └── <version>/
    │           ├── data_description.json (REQUIRED)
-   │           ├── manifest.json (REQUIRED)
-   │           ├── processing.json (REQUIRED IF COMPUTED)
-   │           ├── template.ome.zarr (REQUIRED)
-   │           └── template.nii.gz (OPTIONAL)
+   │           ├── manifest.json         (REQUIRED)
+   │           ├── processing.json       (REQUIRED IF COMPUTED)
+   │           ├── template.ome.zarr     (REQUIRED)
+   │           └── template.nii.gz       (OPTIONAL)
    │
    ├── annotation-sets/
    │   └── <annotation_set_name>/
    │       └── <version>/
-   │           ├── data_description.json (REQUIRED)
-   │           ├── annotations.ome.zarr (REQUIRED)
+   │           ├── data_description.json           (REQUIRED)
+   │           ├── annotations.ome.zarr            (REQUIRED)
    │           ├── annotations_compressed.ome.zarr (OPTIONAL)
-   │           ├── annotations.precomputed (REQUIRED)
-   │           ├── annotations_smooth.precomputed (OPTIONAL)
-   │           ├── parcellation_volumes.csv (OPTIONAL)
-   │           └── manifest.json (REQUIRED)
+   │           ├── annotations.precomputed         (REQUIRED)
+   │           ├── annotations_smooth.precomputed  (OPTIONAL)
+   │           ├── parcellation_volumes.csv        (OPTIONAL)
+   │           └── manifest.json                   (REQUIRED)
    │
    ├── terminologies/
    │   └── <terminology_name>/
    │       └── <version>/
    │           ├── data_description.json (REQUIRED)
-   │           ├── terminology.parquet (OPTIONAL)
-   │           └── terminology.csv (REQUIRED)
+   │           ├── terminology.parquet   (OPTIONAL)
+   │           └── terminology.csv       (REQUIRED)
    │
    ├── coordinate-spaces/
    │   └── <coordinate_space_name>/
    │       └── <version>/
    │           ├── data_description.json (REQUIRED)
-   │           └── manifest.json (REQUIRED)
+   │           └── manifest.json         (REQUIRED)
    │
    └── coordinate-transformations/
        └── <template>-<version>_to_<template>-<version>/
            └── <version>/
-               ├── data_description.json (REQUIRED)
-               ├── processing.json (REQUIRED if computed)
-               ├── manifest.json (REQUIRED)
+               ├── data_description.json               (REQUIRED)
+               ├── processing.json                     (REQUIRED if computed)
+               ├── manifest.json                       (REQUIRED)
                ├── coordinate_transformations.ome.zarr (OPTIONAL)
-               └── <ANTs files> (OPTIONAL)
+               └── <ANTs files>                        (OPTIONAL)
 
 Metadata
 --------

--- a/docs/source/template.rst
+++ b/docs/source/template.rst
@@ -15,11 +15,11 @@ Directory Structure
    templates/
      └── <template_name>/
          └── <version>/
-             ├── data_description.json (REQUIRED)
-             ├── manifest.json         (REQUIRED)
-             ├── processing.json       (REQUIRED IF COMPUTED)
-             ├── template.ome.zarr (REQUIRED)
-             └── template_{resolution}.nii.gz   (OPTIONAL)
+             ├── data_description.json        (REQUIRED)
+             ├── manifest.json                (REQUIRED)
+             ├── processing.json              (REQUIRED IF COMPUTED)
+             ├── template.ome.zarr            (REQUIRED)
+             └── template_{resolution}.nii.gz (OPTIONAL)
 
 Naming Convention
 -----------------


### PR DESCRIPTION
Pad filenames in every directory-structure tree so the (REQUIRED)/(OPTIONAL) markers line up in a single column per block, across all pages and every subtree of the global layout in index.rst. Formatting only; no content changes.