### PR TITLE
docs: add required manifest.json to the terminology spec

### DIFF
--- a/docs/source/changelog.rst
+++ b/docs/source/changelog.rst
@@ -4,6 +4,19 @@ Changelog
 
 This page tracks changes to the Atlas Asset Organization specification.
 
+**v0.1.4 — July 23, 2026** — `HTML <https://atlas-assets.readthedocs.io/en/v0.1.4/>`__ · `GitHub <https://github.com/AllenNeuralDynamics/atlas-assets/releases/tag/v0.1.4>`__
+   Added the required ``manifest.json`` file to the terminology specification.
+
+   Added the optional ``annotations_compressed_{resolution}.nii.gz`` file to the annotation set specification.
+
+   Added the optional ``legacy_files/`` directory to the terminology specification.
+
+   Clarified that naming conventions are recommended guidelines, not requirements.
+
+   Generalized storage wording from "S3 bucket" to "folder or cloud object storage".
+
+   Linked each changelog release to its rendered documentation and GitHub tag.
+
 **v0.1.3 — July 21, 2026** — `HTML <https://atlas-assets.readthedocs.io/en/v0.1.3/>`__ · `GitHub <https://github.com/AllenNeuralDynamics/atlas-assets/releases/tag/v0.1.3>`__
    Reconciled the File Organization layout with the per-asset pages: corrected the annotation set file list, added the required ``manifest.json`` to templates and annotation sets, and added the coordinate spaces directory.
 

--- a/docs/source/index.rst
+++ b/docs/source/index.rst
@@ -158,6 +158,7 @@ The S3 bucket structure is organized as follows:
    │   └── <terminology_name>/
    │       └── <version>/
    │           ├── data_description.json                      (REQUIRED)
+   │           ├── manifest.json                              (REQUIRED)
    │           ├── terminology.parquet                        (OPTIONAL)
    │           ├── terminology.csv                            (REQUIRED)
    │           └── legacy_files/                              (OPTIONAL)

--- a/docs/source/terminology.rst
+++ b/docs/source/terminology.rst
@@ -20,6 +20,7 @@ Only the terminology subtree of the global layout is shown here:
      └── <terminology_name>/
          └── <version>/
              ├── data_description.json (REQUIRED)
+             ├── manifest.json         (REQUIRED)
              ├── terminology.csv       (REQUIRED)
              ├── terminology.parquet   (OPTIONAL)
              └── legacy_files/         (OPTIONAL)
@@ -47,6 +48,14 @@ Files
 -----
 ``data_description.json``
   * Must validate against ``aind_data_schema >= 2.0``. Documents provenance, authorship, license, and high-level context.
+
+``manifest.json``
+  Identifies the terminology release. Minimal required keys (draft):
+
+  * ``name`` – terminology name
+  * ``version`` – terminology version
+  * ``location`` – path to the asset
+  * ``schema_version`` – version of the manifest contract
 
 ``terminology.csv``
   * Canonical tabular definition of the hierarchical set of terms.

--- a/src/atlas_assets/__init__.py
+++ b/src/atlas_assets/__init__.py
@@ -1,2 +1,2 @@
 """Init package"""
-__version__ = "0.1.3"
+__version__ = "0.1.4"


### PR DESCRIPTION
Terminology assets carry a manifest.json (name, version, location, schema_version) in practice, but the spec omitted it. Add it as a required file to the terminology directory tree and Files section, and to the global layout in index.rst.