### PR TITLE
docs: drop 'alignment' from the template manifest

### DIFF
--- a/docs/source/template.rst
+++ b/docs/source/template.rst
@@ -50,8 +50,8 @@ Files
 ``manifest.json``
   * References the Coordinate Space this template defines or is aligned to. Minimal required keys (draft):
 
-    * ``coordinate_space`` – object with ``name`` and ``version``
-    * ``alignment`` – this template's relationship to the Coordinate Space: ``defining`` (the template defines the space) or ``aligned`` (rigidly/affinely aligned to it)
+    * ``coordinate_space`` – object with ``name`` and ``version``; also
+      conveys the template that defined the coordinate space
     * ``created`` – ISO 8601 date/time
     * ``schema_version`` – version of the manifest contract
 

--- a/src/atlas_assets/validation/spec.py
+++ b/src/atlas_assets/validation/spec.py
@@ -65,7 +65,6 @@ ASSET_SPECS = {
         ],
         manifest_keys={
             "coordinate_space",
-            "alignment",
             "created",
             "schema_version",
         },

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -19,7 +19,6 @@ from atlas_assets.validation.store import AssetStore
 
 _TEMPLATE_MANIFEST = {
     "coordinate_space": {"name": "s", "version": "2015"},
-    "alignment": "defining",
     "created": "2015-01-01",
     "schema_version": "0.1.0",
 }


### PR DESCRIPTION
The template-to-space alignment is conveyed by the coordinate_space reference (which template defined the space), so a separate 'alignment' manifest key is redundant. Remove it from the template manifest spec and from the validator's draft manifest-key check.