### PR TITLE
docs: enumerate manifest keys for coordinate spaces and annotation sets

### DIFF
--- a/docs/source/annotation_set.rst
+++ b/docs/source/annotation_set.rst
@@ -67,7 +67,20 @@ Files
   * Columns: ``identifier``, ``voxel_count``, ``volume_mm3``
 
 ``manifest.json``
-  * References the terminology name/version and coordinate space version, including component paths.
+  Identifies the annotation set and its components. Minimal required
+  keys (draft):
+
+  * ``name`` – annotation set name
+  * ``version`` – annotation set version
+  * ``location`` – path to the asset
+  * ``schema_version`` – version of the manifest contract
+  * ``coordinate_space`` – object (``name``, ``version``) identifying the
+    coordinate space
+  * ``terminology`` – object (``name``, ``version``) identifying the
+    terminology
+  * ``template`` – (optional) object (``name``, ``version``) identifying
+    the reference template
+  * ``scales`` – list of resolutions available (e.g. ``[10, 25, 50, 100]``)
 
 ``data_description.json``
   * ``aind_data_schema >= 2.0``: includes administrative metadata, description, provenance, authorship, licensing, references

--- a/docs/source/coordinate_space.rst
+++ b/docs/source/coordinate_space.rst
@@ -42,7 +42,16 @@ Files
   Must validate against ``aind_data_schema >= 2.0``. Documents administrative metadata.
 
 ``manifest.json``
-  Documents the origin, spacing (including units), and defining anatomical template.
+  Documents the coordinate space. Minimal required keys (draft):
+
+  * ``name`` – coordinate space name
+  * ``version`` – coordinate space version
+  * ``location`` – path to the asset
+  * ``schema_version`` – version of the manifest contract
+  * ``origin`` – anatomical origin of the coordinate system
+  * ``spacing`` – physical voxel spacing, including units
+  * ``template`` – object (``name``, ``version``) identifying the
+    template that defines the space
 
 
 Versioning

--- a/src/atlas_assets/validation/spec.py
+++ b/src/atlas_assets/validation/spec.py
@@ -82,6 +82,15 @@ ASSET_SPECS = {
         optional_file_patterns=[
             re.compile(r"^annotations_compressed_" + _RES + r"\.nii\.gz$")
         ],
+        manifest_keys={
+            "name",
+            "version",
+            "location",
+            "schema_version",
+            "coordinate_space",
+            "terminology",
+            "scales",
+        },
         name_suffix="-annotation",
     ),
     "terminologies": AssetSpec(
@@ -99,6 +108,15 @@ ASSET_SPECS = {
     "coordinate-spaces": AssetSpec(
         type_dir="coordinate-spaces",
         required_files={"data_description.json", "manifest.json"},
+        manifest_keys={
+            "name",
+            "version",
+            "location",
+            "schema_version",
+            "origin",
+            "spacing",
+            "template",
+        },
         name_suffix="-space",
     ),
     "coordinate-transformations": AssetSpec(


### PR DESCRIPTION
Spell out the draft minimal manifest keys for both asset types (as the atlas/template/terminology pages already do) and check them in the validator:

* coordinate spaces: name, version, location, schema_version, origin, spacing, and template (the defining reference image). rc11's identity-only space manifests are incomplete and now flag missing origin/spacing/template.
* annotation sets: name, version, location, schema_version, coordinate_space, terminology, scales, and an optional template.