### PR TITLE
docs: drop 'created' from atlas and template manifest keys

### DIFF
--- a/docs/source/atlas.rst
+++ b/docs/source/atlas.rst
@@ -50,7 +50,6 @@ Files
   * ``coordinate_space`` – object with ``name`` and ``version``
   * ``templates`` – list of objects, each with ``name`` and ``version``
   * ``annotation_sets`` – list of objects, each with ``name`` and ``version`` (terminology is referenced by the annotation set itself)
-  * ``created`` – ISO 8601 date/time of atlas release
   * ``schema_version`` – version of future ``atlas-schema`` manifest contract
 
 Validation Rules

--- a/docs/source/template.rst
+++ b/docs/source/template.rst
@@ -52,7 +52,6 @@ Files
 
     * ``coordinate_space`` – object with ``name`` and ``version``; also
       conveys the template that defined the coordinate space
-    * ``created`` – ISO 8601 date/time
     * ``schema_version`` – version of the manifest contract
 
 ``processing.json``

--- a/src/atlas_assets/validation/spec.py
+++ b/src/atlas_assets/validation/spec.py
@@ -50,7 +50,6 @@ ASSET_SPECS = {
             "coordinate_space",
             "templates",
             "annotation_sets",
-            "created",
             "schema_version",
         },
         name_suffix="-atlas",
@@ -65,7 +64,6 @@ ASSET_SPECS = {
         ],
         manifest_keys={
             "coordinate_space",
-            "created",
             "schema_version",
         },
         name_suffix="-template",


### PR DESCRIPTION
The release timestamp is already captured in data_description.json (aind-data-schema metadata), so requiring a 'created' key in the atlas and template manifests is redundant. Remove it from both specs and from the validator's manifest-key check.